### PR TITLE
Use `MonadHandler` constraint

### DIFF
--- a/src/Yesod/Form/Summernote.hs
+++ b/src/Yesod/Form/Summernote.hs
@@ -67,8 +67,9 @@ class Yesod a => YesodSummernote a where
 -- @
 -- snHtmlFieldCustomized "{ height: 150, codemirror: { theme:'monokai' } }"
 -- @
-snHtmlFieldCustomized :: YesodSummernote site
-                      => String -> Field (HandlerT site IO) Html
+snHtmlFieldCustomized :: (YesodSummernote site, MonadHandler m)
+                      => String
+                      -> Field (HandlerT site m) Html
 snHtmlFieldCustomized cfg = Field
     { fieldParse =
         \e _ -> return $
@@ -98,7 +99,8 @@ $(document).ready(function(){
     showVal = either id (pack . renderHtml)
 
 -- | Summernote editor field with default settings.
-snHtmlField :: YesodSummernote site => Field (HandlerT site IO) Html
+snHtmlField :: (YesodSummernote site, MonadHandler m)
+            => Field (HandlerT site m) Html
 snHtmlField = snHtmlFieldCustomized ""
 
 


### PR DESCRIPTION
This removes the hard dependency on running in `IO` and instead requires to run in any `m` that has a `MonadHandler` instance. Fixes #2.